### PR TITLE
DEV: Move settings descriptions to locales/en.yml

### DIFF
--- a/about.json
+++ b/about.json
@@ -1,6 +1,6 @@
 {
   "about_url": "https://meta.discourse.org/t/custom-profile-link/295470",
-  "license_url": null,
+  "license_url": "https://github.com/discourse/discourse-profile-custom-link/blob/main/LICENSE",
   "assets": {},
   "name": "Custom Profile Link",
   "component": true

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,3 +1,8 @@
 en:
   theme_metadata:
     description: "Provides the option to add an external link on the user profile."
+    settings:
+      profile_custom_link_field: "The exact name (case sensitive) of the custom user input field used to add an external link on the profile. For example, 'Github username'. If empty, the Discourse username will be used."
+      profile_custom_link_prefix: "The base url for the external link user input field. For example, 'http://github.com/'."
+      profile_custom_link_label: "The label that will be used to display the generated link. For example, 'GitHub'."
+      profile_custom_link_icon: "The icon to be used for the external link."

--- a/settings.yml
+++ b/settings.yml
@@ -1,15 +1,11 @@
 profile_custom_link_field:
   type: string
   default: ""
-  description: "The exact name (case sensitive) of the custom user input field used to add an external link on the profile. For example, 'Github username'. If empty, the Discourse username will be used."
 profile_custom_link_prefix:
   type: string
   default: ""
-  description: "The base url for the external link user input field. For example, 'http://github.com/'."
 profile_custom_link_label:
   type: string
   default: ""
-  description: "The label that will be used to display the generated link. For example, 'GitHub'."
 profile_custom_link_icon:
   default: "external-link-alt"
-  description: "The the icon to be used for the external link."


### PR DESCRIPTION
This makes translations of the strings with Crowdin possible. I also added the link to the license file to about.json and removed the double "the" in the description of the icon setting.